### PR TITLE
Fix default sidebar behavior

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -50,7 +50,7 @@ class HandleInertiaRequests extends Middleware
                 ...(new Ziggy)->toArray(),
                 'location' => $request->url(),
             ],
-            'sidebarOpen' => $request->cookie('sidebar_state') === 'true',
+            'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
         ];
     }
 }


### PR DESCRIPTION
This PR fixes the default sidebar behavior when a user loads the page the first time. Since #72 was merged the default behavior changed from open to collapsed which is inconsistent with the current default in the starter kits and the accompanying PR in the Vue starter kit repo: https://github.com/laravel/vue-starter-kit/pull/82